### PR TITLE
remove hover and highlight

### DIFF
--- a/flow_screen_components/lookupFSC/mdapi/aura/LightningLookup/LightningLookup.cmp
+++ b/flow_screen_components/lookupFSC/mdapi/aura/LightningLookup/LightningLookup.cmp
@@ -100,7 +100,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 						aria-owns="lookup-65" role="combobox" 
 						aria-activedescendant="" aria-expanded="false" aria-autocomplete="list" 
 						disabled="{!v.disabled}" oninput="{!c.performLookup}" onclick="{!c.toggleMenu }"
-						onblur="{!c.checkValidity}" onkeydown="{!c.highlight}"/>
+						onblur="{!c.checkValidity}" />
 				<div aura:id="pillsdiv"/>
 				<lightning:icon class="searchIcon" iconName="utility:search" size="x-small" aura:id="search_icon"
 								alternativeText="Search"/>
@@ -113,7 +113,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		<div class="slds-lookup__menu" id="lookup-65" >
 			<ul class="slds-lookup__list" role="listbox" aura:id="diplayedul">
 				<aura:iteration var="item" items="{!v.matchedListDisplay}" indexVar="idx">
-					<li role="presentation" data-index="{!idx}" onclick="{!c.selectItem}" onmouseover="{!c.hover}" class="push-down">
+					<li role="presentation" data-index="{!idx}" onclick="{!c.selectItem}" class="push-down">
 						<aura:renderIf isTrue="{!v.svg != null}">
 							<lightning:icon iconName="{!v.svg}" size="x-small" />
 						</aura:renderIf>


### PR DESCRIPTION
Hover and highlight are not currently defined by the controller so they break use of this component when used on mobile devices and throw ugly errors on desktop. Hover and highlight should be added to the controller in the future and can then be reintroduced to this code.